### PR TITLE
Allow omission of for macro index binding

### DIFF
--- a/src/app/core.cljs
+++ b/src/app/core.cljs
@@ -96,7 +96,7 @@
                         :grid-template-rows "repeat(5, 1fr)"
                         :gap 1
                         :background-color "#6c6058"}}
-          (s/for [[v idx] buttons]
+          (s/for [[v] buttons]
             ($ button {:on-click #(on-click v)
                        :style {:grid-column (when (= v 0) "span 2")
                                :background-color (cond

--- a/src/solid/core.clj
+++ b/src/solid/core.clj
@@ -37,10 +37,11 @@
     ($ :li x))
   ```"
   [[[v idx] expr] body]
-  `(-for (fn [] (js/Array.from ~expr))
-         (fn [~v idx#]
-           (let [~idx (-wrap idx#)]
-             ~body))))
+  (let [idx (or idx '_)]
+    `(-for (fn [] (js/Array.from ~expr))
+           (fn [~v idx#]
+             (let [~idx (-wrap idx#)]
+               ~body)))))
 
 (defmacro index
   "Solid's `Index` component in Clojure’s `for` syntax


### PR DESCRIPTION
Hello! I was trying out this wrapper and came across a problem when writing using `s/for` like this:

```clojure
(s/for [[v] some-sequence] ; no index binding
  ...)
```

Shadow throws an unhelpful macroexpansion error in this case. This PR allows the caller to omit the index binding and avoid the confusing error. What do you think?

Thanks for the library, BTW. This is looking like a promising alternative to the many CLJS+React solutions out there.