### PR TITLE
Fixes the test run (npm run test):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solid-cljs",
   "scripts": {
-    "test": "shadow-cljs compile test && node out/test.js",
+    "test": "shadow-cljs compile test && node -C browser out/test.js",
     "test:watch": "shadow-cljs watch test",
     "example": "shadow-cljs watch app",
     "release": "shadow-cljs release app",

--- a/src/solid/core.cljs
+++ b/src/solid/core.cljs
@@ -57,9 +57,9 @@
   (let [value (volatile! nil)
         f #(vreset! value %)]
     (specify! f
-      IDeref
-      (-deref [this]
-        @value))))
+              IDeref
+              (-deref [this]
+                      @value))))
 
 (defn effect
   ([f]
@@ -100,11 +100,11 @@
 
 (defn -switch [else pairs]
   (apply h solid/Switch
-     #js {:fallback else}
-     (for [[test then] pairs]
-       (h solid/Match
-          #js {:when test}
-          then))))
+         #js {:fallback else}
+         (for [[test then] pairs]
+           (h solid/Match
+              #js {:when test}
+              then))))
 
 (defn -dynamic [f]
   (h sw/Dynamic #js {:component f}))
@@ -121,11 +121,11 @@
       (if (reactive-prop? v)
         ((.-getter ^ReactiveProp v))  ; Call the reactive getter
         v)))            ; Pass through as-is (callbacks, literals, etc.)
-  
+
   ISeqable
   (-seq [this]
     (seq props-map))
-  
+
   ICounted
   (-count [this]
     (count props-map)))
@@ -136,12 +136,12 @@
           children (-children #(.-children props))]
       (->ReactiveProps
         (cond-> clj-props
-                children (assoc :children children))))))
+          children (assoc :children children))))))
 
 (defn -error-boundary [fallback & children]
   (apply h solid/ErrorBoundary
-     #js {:fallback fallback}
-     children))
+         #js {:fallback fallback}
+         children))
 
 (defn -lazy [f]
   (solid/lazy f))
@@ -232,8 +232,8 @@
 (defn pipe-to [stream res]
   (.pipeTo ^js stream res))
 
-(defn server? []
-  (sw/isServer))
+(def server?
+  sw/isServer)
 
 (defn dev? []
   solid/DEV)

--- a/test/solid/core_test.cljs
+++ b/test/solid/core_test.cljs
@@ -90,8 +90,7 @@
 
 (deftest server?-test
   (testing "isServer check"
-    (let [result (s/server?)]
-      (is (boolean? result) "server? should return a boolean"))))
+    (is (boolean? s/server?) "server? should return a boolean")))
 
 (deftest dev?-test
   (testing "DEV check"
@@ -219,4 +218,5 @@
   (testing "deferred value"
     (let [sig (s/signal 5)
           deferred-val (s/deferred #(* 2 @sig))]
-      (is (fn? deferred-val) "deferred should return a function"))))
+      (is (= (deferred-val) 10) "deferred should return the correct calculation"))))
+

--- a/test/solid/test_runner.cljs
+++ b/test/solid/test_runner.cljs
@@ -3,4 +3,8 @@
             [solid.core-test]))
 
 (defn main [& args]
-  (run-tests 'solid.core-test))
+  (run-tests 'solid.core-test)
+  ; `createDeferred` will hang the thread for some odd reason,
+  ; use process.exit to finish the run.
+  ; - https://github.com/solidjs/solid/issues/2570
+  (js/process.exit 0))


### PR DESCRIPTION
Fixes the 3 tests that were failing:

- createEffect is fixed by using 'node -C browser', in order to allow effects to execute, otherwise it stubs them out for server-side rendering
- isServer is just a variable, so remove the function call
- createDeferred hangs the process, so use process.exit

Result:

```
Ran 23 tests containing 33 assertions.
0 failures, 0 errors.
```

**Comment**

`node -C browser` seems undocumented atm, someone on the Discord server hinted me that it was a thing 🤔 [Reference issue](https://github.com/solidjs/solid/issues/2569)

Also my cljfmt is editing some of of the whitespace in `src/solid/core.cljs`, basically I am using `{:function-arguments-indentation :zprint}`, I didn't find a `cljfmt` config in this project so I am just leaving in these changes for now, makes it simpler to work for me. Adding `cljfmt` to the project might be a good idea.